### PR TITLE
Convert YAML file paths to abspath

### DIFF
--- a/sphinx_mdolab_theme/__init__.py
+++ b/sphinx_mdolab_theme/__init__.py
@@ -2,7 +2,7 @@ from os import path
 import sphinx
 
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"
 __version_full__ = __version__
 
 

--- a/sphinx_mdolab_theme/ext/optionslist.py
+++ b/sphinx_mdolab_theme/ext/optionslist.py
@@ -111,6 +111,8 @@ class OptionsList(Include):
     def get_descriptions(self):
         if "filename" in self.options:
             self.filename = self.options["filename"]
+        source_file = self.state.document.attributes["source"]
+        self.filename = os.path.join(os.path.dirname(source_file), self.filename)
         if not os.path.isfile(self.filename):
             raise FileNotFoundError(f"The file {self.filename} must exist! Failed module is {self.member_name}.")
 

--- a/sphinx_mdolab_theme/ext/optionstable.py
+++ b/sphinx_mdolab_theme/ext/optionstable.py
@@ -67,6 +67,8 @@ class OptionsTable(Table):
     def get_descriptions(self):
         if "filename" in self.options:
             self.filename = self.options["filename"]
+        source_file = self.state.document.attributes["source"]
+        self.filename = os.path.join(os.path.dirname(source_file), self.filename)
         if not os.path.isfile(self.filename):
             raise FileNotFoundError(f"The file {self.filename} must exist! Failed module is {self.member_name}.")
 


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
In order to support out-of-source builds (say via VS code extensions), I have converged the input filepath for the YAML options to use abspath, by fetching the source RST file that called the extension via `self.state.document.attributes["source"]`. This does mean however that the specified file path should be relative to the RST file itself, rather than the root `doc` directory where `conf.py` is stored (i.e. the directory you call sphinx from). The only package where this affects things should be pyOptSparse, and I will push a fix for that soon.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
ASAP

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->
Tested on ADflow and pyOptSparse.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [x] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
