### PR TITLE
Adding OpenMDAO Sphinx Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode
+*egg-info*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,9 +1,0 @@
-[isort]
-profile=black
-line_length=120
-force_sort_within_sections=true
-import_heading_stdlib=Standard Python modules
-import_heading_thirdparty=External modules
-import_heading_firstparty=First party modules
-import_heading_localfolder=Local modules
-skip_glob=**__init__.py,**setup.py

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[isort]
+profile=black
+line_length=120
+force_sort_within_sections=true
+import_heading_stdlib=Standard Python modules
+import_heading_thirdparty=External modules
+import_heading_firstparty=First party modules
+import_heading_localfolder=Local modules
+skip_glob=**__init__.py,**setup.py

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,8 @@ setup(
         "sphinx-copybutton",
         "sphinxcontrib-autoprogram",
         "sphinxcontrib-bibtex",
+        "redbaron",
+        "numpy",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",  # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package

--- a/sphinx_mdolab_theme/ext/embed_bibtex.py
+++ b/sphinx_mdolab_theme/ext/embed_bibtex.py
@@ -1,0 +1,76 @@
+# Standard Python modules
+import importlib
+
+# External modules
+from docutils import nodes
+from docutils.parsers.rst import Directive
+import sphinx
+from sphinx.errors import SphinxError
+from sphinx.writers.html5 import HTML5Translator
+from sphinx.writers.html import HTMLTranslator
+
+
+class bibtex_node(nodes.Element):
+    pass
+
+
+def visit_bibtex_node(self, node):
+    pass
+
+
+def depart_bibtex_node(self, node):
+    """
+    This function creates the formatting that sets up the look of the blocks.
+    The look of the formatting is controlled by _theme/static/style.css
+    """
+    if not isinstance(self, (HTMLTranslator, HTML5Translator)):
+        self.body.append("output only available for HTML\n")
+        return
+
+    html = """
+    <div class="cell border-box-sizing code_cell rendered">
+       <div class="output_area"><pre>{}</pre></div>
+    </div>""".format(
+        node["text"]
+    )
+
+    self.body.append(html)
+
+
+class EmbedBibtexDirective(Directive):
+    """
+    EmbedBibtexDirective is a custom directive to allow a Bibtex citation to be embedded.
+
+    .. embed-bibtex::
+        openmdao.solvers.linear.petsc_ksp
+        PETScKrylov
+
+
+    The 2 arguments are the module path and the class name.
+
+    What the above will do is replace the directive and its args with the Bibtex citation
+    for the class.
+
+    """
+
+    required_arguments = 2
+    optional_arguments = 0
+    has_content = True
+
+    def run(self):
+        module_path, class_name = self.arguments
+        mod = importlib.import_module(module_path)
+        obj = getattr(mod, class_name)()
+
+        if not hasattr(obj, "cite") or not obj.cite:
+            raise SphinxError("Couldn't find 'cite' in class '%s'" % class_name)
+
+        return [bibtex_node(text=obj.cite)]
+
+
+def setup(app):
+    """add custom directive into Sphinx so that it is found during document parsing"""
+    app.add_directive("embed-bibtex", EmbedBibtexDirective)
+    app.add_node(bibtex_node, html=(visit_bibtex_node, depart_bibtex_node))
+
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/sphinx_mdolab_theme/ext/embed_code.py
+++ b/sphinx_mdolab_theme/ext/embed_code.py
@@ -1,0 +1,321 @@
+# Standard Python modules
+import inspect
+import os
+import re
+import traceback
+import unittest
+
+# External modules
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives import images, unchanged
+import sphinx
+from sphinx.errors import SphinxError
+
+# First party modules
+from sphinx_mdolab_theme.utils.docutil import (
+    consolidate_input_blocks,
+    dedent,
+    extract_output_blocks,
+    get_interleaved_io_nodes,
+    get_output_block_node,
+    get_skip_output_node,
+    get_source_code,
+    insert_output_start_stop_indicators,
+    node_setup,
+    remove_docstrings,
+    remove_initial_empty_lines,
+    replace_asserts_with_prints,
+    run_code,
+    split_source_into_input_blocks,
+    strip_decorators,
+    strip_header,
+)
+
+_plot_count = 0
+
+plotting_functions = ["\.show\(", "partial_deriv_plot\("]
+
+
+class EmbedCodeDirective(Directive):
+    """
+    EmbedCodeDirective is a custom directive to allow blocks of
+    python code to be shown in feature docs.  An example usage would look like this:
+
+    .. embed-code::
+        openmdao.test.whatever.method
+
+    What the above will do is replace the directive and its args with the block of code
+    for the class or method desired.
+
+    By default, docstrings will be kept in the embedded code. There is an option
+    to the directive to strip the docstrings:
+
+    .. embed-code::
+        openmdao.test.whatever.method
+        :strip-docstrings:
+    """
+
+    # must have at least one directive for this to work
+    required_arguments = 1
+    has_content = True
+
+    option_spec = {
+        "strip-docstrings": unchanged,
+        "layout": unchanged,
+        "scale": unchanged,
+        "align": unchanged,
+        "imports-not-required": unchanged,
+    }
+
+    def run(self):
+        global _plot_count
+
+        #
+        # error checking
+        #
+        allowed_layouts = set(["code", "output", "interleave", "plot"])
+
+        if "layout" in self.options:
+            layout = [s.strip() for s in self.options["layout"].split(",")]
+        else:
+            layout = ["code"]
+
+        if len(layout) > len(set(layout)):
+            raise SphinxError("No duplicate layout entries allowed.")
+
+        bad = [n for n in layout if n not in allowed_layouts]
+        if bad:
+            raise SphinxError("The following layout options are invalid: %s" % bad)
+
+        if "interleave" in layout and ("code" in layout or "output" in layout):
+            raise SphinxError("The interleave option is mutually exclusive to the code " "and output options.")
+
+        #
+        # Get the source code
+        #
+        path = self.arguments[0]
+        try:
+            source, indent, module, class_, method = get_source_code(path)
+        except Exception as err:
+            # Generally means the source couldn't be inspected or imported.
+            # Raise as a Directive warning (level 2 in docutils).
+            # This way, the sphinx build does not terminate if, for example, you are building on
+            # an environment where mpi or pyoptsparse are missing.
+            raise self.directive_error(2, str(err))
+
+        #
+        # script, test and/or plot?
+        #
+        # is_script = path.endswith(".py")
+
+        is_test = class_ is not None and inspect.isclass(class_) and issubclass(class_, unittest.TestCase)
+
+        shows_plot = re.compile("|".join(plotting_functions)).search(source)
+
+        if "plot" in layout:
+            plot_dir = os.getcwd()
+            plot_fname = "doc_plot_%d.png" % _plot_count
+            _plot_count += 1
+
+            plot_file_abs = os.path.join(os.path.abspath(plot_dir), plot_fname)
+            if os.path.isfile(plot_file_abs):
+                # remove any existing plot file
+                os.remove(plot_file_abs)
+
+        #
+        # Modify the source prior to running
+        #
+        if "strip-docstrings" in self.options:
+            source = remove_docstrings(source)
+
+        setup_code = ""
+        teardown_code = ""
+        mpl_import = ""
+        mpl_figure = ""
+
+        if is_test:
+            try:
+                source = dedent(source)
+                source = strip_decorators(source)
+                source = strip_header(source)
+                source = dedent(source)
+                source = replace_asserts_with_prints(source)
+                source = remove_initial_empty_lines(source)
+
+                class_name = class_.__name__
+                method_name = path.rsplit(".", 1)[1]
+
+                # make 'self' available to test code (as an instance of the test case)
+                self_code = "from %s import %s\nself = %s('%s')\n" % (
+                    module.__name__,
+                    class_name,
+                    class_name,
+                    method_name,
+                )
+
+                # get setUp and tearDown but don't duplicate if it is the method being tested
+                setup_code = (
+                    ""
+                    if method_name == "setUp"
+                    else dedent(strip_header(remove_docstrings(inspect.getsource(getattr(class_, "setUp")))))
+                )
+
+                teardown_code = (
+                    ""
+                    if method_name == "tearDown"
+                    else dedent(strip_header(remove_docstrings(inspect.getsource(getattr(class_, "tearDown")))))
+                )
+
+                # for interleaving, we need to mark input/output blocks
+                if "interleave" in layout:
+                    interleaved = insert_output_start_stop_indicators(source)
+                    code_to_run = "\n".join([self_code, setup_code, interleaved, teardown_code]).strip()
+                else:
+                    code_to_run = "\n".join([self_code, setup_code, source, teardown_code]).strip()
+            except Exception:
+                err = traceback.format_exc()
+                raise SphinxError("Problem with embed of " + path + ": \n" + str(err))
+        else:
+            if indent > 0:
+                source = dedent(source)
+            if "interleave" in layout:
+                source = insert_output_start_stop_indicators(source)
+            code_to_run = source[:]
+
+        #
+        # Run the code (if necessary)
+        #
+        skipped = failed = False
+
+        if "output" in layout or "interleave" in layout or "plot" in layout:
+
+            imports_not_required = "imports-not-required" in self.options
+
+            if shows_plot:
+                # NOTE: import matplotlib AFTER __future__ (if it's there)
+                # All use of __future__ has been removed from OpenMDAO with v3.x
+                # so the related code has been removed here as well.
+                mpl_import = "\n".join(
+                    [
+                        "import warnings",
+                        "import matplotlib",
+                        "warnings.filterwarnings('ignore')",
+                        "matplotlib.use('Agg')\n",
+                    ]
+                )
+                code_to_run = mpl_import + code_to_run
+
+                if "plot" in layout:
+                    mpl_figure = '\nmatplotlib.pyplot.savefig("%s")' % plot_file_abs
+                    code_to_run = code_to_run + mpl_figure
+
+            if is_test and getattr(method, "__unittest_skip__", False):
+                skipped = True
+                failed = False
+                run_outputs = method.__unittest_skip_why__
+            else:
+                skipped, failed, run_outputs = run_code(
+                    code_to_run,
+                    path,
+                    module=module,
+                    cls=class_,
+                    imports_not_required=imports_not_required,
+                    shows_plot=shows_plot,
+                )
+
+        #
+        # Handle output
+        #
+        if failed:
+            # Failed cases raised as a Directive warning (level 2 in docutils).
+            # This way, the sphinx build does not terminate if, for example, you are building on
+            # an environment where mpi or pyoptsparse are missing.
+            raise self.directive_error(2, run_outputs)
+        elif skipped:
+            # When building docs for a pull request, we do not want the build to fail due to not
+            # having SNOPT (since PRs will not have access to SNOPT).  We want all other warnings.
+            TRAVIS_PR = os.environ.get("TRAVIS_PULL_REQUEST")
+            GITHUB_EV = os.environ.get("GITHUB_EVENT_NAME")
+            PR = (TRAVIS_PR and TRAVIS_PR != "false") or (GITHUB_EV and GITHUB_EV == "pull_request")
+            if not (PR and "pyoptsparse is not providing SNOPT" in run_outputs):
+                self.state_machine.reporter.warning(run_outputs)
+
+            io_nodes = [get_skip_output_node(run_outputs)]
+
+        else:
+            if "output" in layout:
+                output_blocks = run_outputs if isinstance(run_outputs, list) else [run_outputs]
+
+            elif "interleave" in layout:
+                if is_test:
+                    start = len(self_code) + len(setup_code) + len(mpl_import)
+                    end = len(code_to_run) - len(teardown_code) - len(mpl_figure)
+                    input_blocks = split_source_into_input_blocks(code_to_run[start:end])
+                else:
+                    input_blocks = split_source_into_input_blocks(code_to_run)
+
+                output_blocks = extract_output_blocks(run_outputs)
+
+                # Merge any input blocks for which there is no corresponding output
+                # with subsequent input blocks that do have output
+                input_blocks = consolidate_input_blocks(input_blocks, output_blocks)
+
+            if "plot" in layout:
+                if not os.path.isfile(plot_file_abs):
+                    raise SphinxError("Can't find plot file '%s'" % plot_file_abs)
+
+                directive_dir = os.path.relpath(os.getcwd(), os.path.dirname(self.state.document.settings._source))
+                # this filename must NOT contain an absolute path, else the Figure will not
+                # be able to find the image file in the generated html dir.
+                plot_file = os.path.join(directive_dir, plot_fname)
+
+                # create plot node
+                fig = images.Figure(
+                    self.name,
+                    [plot_file],
+                    self.options,
+                    self.content,
+                    self.lineno,
+                    self.content_offset,
+                    self.block_text,
+                    self.state,
+                    self.state_machine,
+                )
+                plot_nodes = fig.run()
+
+        #
+        # create a list of document nodes to return based on layout
+        #
+        doc_nodes = []
+        skip_fail_shown = False
+        for opt in layout:
+            if opt == "code":
+                # we want the body of code to be formatted and code highlighted
+                body = nodes.literal_block(source, source)
+                body["language"] = "python"
+                doc_nodes.append(body)
+            elif skipped:
+                if not skip_fail_shown:
+                    body = nodes.literal_block(source, source)
+                    body["language"] = "python"
+                    doc_nodes.append(body)
+                    doc_nodes.extend(io_nodes)
+                    skip_fail_shown = True
+            else:
+                if opt == "interleave":
+                    doc_nodes.extend(get_interleaved_io_nodes(input_blocks, output_blocks))
+                elif opt == "output":
+                    doc_nodes.append(get_output_block_node(output_blocks))
+                else:  # plot
+                    doc_nodes.extend(plot_nodes)
+
+        return doc_nodes
+
+
+def setup(app):
+    """add custom directive into Sphinx so that it is found during document parsing"""
+    app.add_directive("embed-code", EmbedCodeDirective)
+    node_setup(app)
+
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/sphinx_mdolab_theme/ext/embed_code.py
+++ b/sphinx_mdolab_theme/ext/embed_code.py
@@ -158,13 +158,13 @@ class EmbedCodeDirective(Directive):
                 setup_code = (
                     ""
                     if method_name == "setUp"
-                    else dedent(strip_header(remove_docstrings(inspect.getsource(getattr(class_, "setUp")))))
+                    else dedent(strip_header(remove_docstrings(inspect.getsource(class_.setUp))))
                 )
 
                 teardown_code = (
                     ""
                     if method_name == "tearDown"
-                    else dedent(strip_header(remove_docstrings(inspect.getsource(getattr(class_, "tearDown")))))
+                    else dedent(strip_header(remove_docstrings(inspect.getsource(class_.tearDown))))
                 )
 
                 # for interleaving, we need to mark input/output blocks

--- a/sphinx_mdolab_theme/ext/embed_compare.py
+++ b/sphinx_mdolab_theme/ext/embed_compare.py
@@ -1,0 +1,142 @@
+""" Sphinx directive for a side by side code comparison."""
+
+# External modules
+from docutils import nodes
+from docutils.parsers.rst import Directive
+import sphinx
+
+# First party modules
+from sphinx_mdolab_theme.utils.docutil import get_source_code
+
+
+class ContentContainerDirective(Directive):
+    """
+    Just for having an outer div.
+
+    Relevant CSS: rosetta_outer
+    """
+
+    has_content = True
+    optional_arguments = 1
+
+    def run(self):
+        self.assert_has_content()
+        text = "\n".join(self.content)
+        node = nodes.container(text)
+        node["classes"].append("rosetta_outer")
+
+        if self.arguments and self.arguments[0]:
+            node["classes"].append(self.arguments[0])
+
+        self.add_name(node)
+        self.state.nested_parse(self.content, self.content_offset, node)
+        return [node]
+
+
+class EmbedCompareDirective(Directive):
+    """
+    EmbedCompareDirective is a custom directive to allow blocks of
+    python code to be shown side by side to compare the new API with the old API. An
+    exmple looks like this:
+
+    .. embed-compare::
+        openmdao.test.whatever.method
+        optional text for searching for the first line
+        optional text for searching for the end line
+        optional style
+
+      Old OpenMDAO lines of code go here.
+
+    What the above will do is replace the directive and its args with the block of code
+    containing the class for method1 on the left and the class for method2 on the right.
+
+    For optional styles, use 'style2' to use the alternate CSS style that has a light background on
+    both sides instead of red and green. Use 'no_compare' for straight code embedding without the
+    side-by-side comparison. (This is for pasting fragments of pre-tested code from a test.)
+
+    Relevant CSS: rosetta_left and rosetta_right
+    """
+
+    # must have at least one directive for this to work
+    required_arguments = 1
+    optional_arguments = 3
+    has_content = True
+
+    def run(self):
+        arg = self.arguments
+        compare = True
+
+        # create a list of document nodes to return
+        doc_nodes = []
+
+        # Choose style
+        left_style = "rosetta_left"
+        right_style = "rosetta_right"
+        if len(arg) == 4:
+            if arg[3] == "style2":
+                left_style = "rosetta_left2"
+                right_style = "rosetta_right2"
+            elif arg[3] == "no_compare":
+                compare = False
+
+        # LEFT side = Old OpenMDAO
+        if compare:
+            text = "\n".join(self.content)
+            left_body = nodes.literal_block(text, text)
+            left_body["language"] = "python"
+            left_body["classes"].append(left_style)
+
+        # for RIGHT side, get the code block, and reduce it if requested
+        right_method = arg[0]
+        text, _, _, _, _ = get_source_code(right_method)
+        if len(arg) >= 3:
+            start_txt = arg[1]
+            end_txt = arg[2]
+            lines = text.split("\n")
+
+            istart = 0
+            for j, line in enumerate(lines):
+                if start_txt in line:
+                    istart = j
+                    break
+
+            lines = lines[istart:]
+            iend = len(lines)
+            for j, line in enumerate(lines):
+                if end_txt in line:
+                    iend = j + 1
+                    break
+
+            lines = lines[:iend]
+
+            # Remove the check suppression.
+            for j, line in enumerate(lines):
+                if "prob.setup(check=False" in line:
+                    lines[j] = lines[j].replace("check=False, ", "")
+                    lines[j] = lines[j].replace("check=False", "")
+
+            # prune whitespace down to match first line
+            while lines[0].startswith("    "):
+                lines = [line[4:] for line in lines]
+
+            text = "\n".join(lines)
+
+        # RIGHT side = Current OpenMDAO
+        right_body = nodes.literal_block(text, text)
+        right_body["language"] = "python"
+        if compare:
+            right_body["classes"].append(right_style)
+
+        if compare:
+            doc_nodes.append(left_body)
+        doc_nodes.append(right_body)
+
+        return doc_nodes
+
+
+def setup(app):
+    """add custom directive into Sphinx so that it is found during document parsing"""
+    app.add_directive("content-container", ContentContainerDirective)
+    app.add_directive("embed-compare", EmbedCompareDirective)
+
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/sphinx_mdolab_theme/ext/embed_n2.py
+++ b/sphinx_mdolab_theme/ext/embed_n2.py
@@ -1,0 +1,109 @@
+# Standard Python modules
+import os.path
+import subprocess
+
+# External modules
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.statemachine import ViewList
+import sphinx
+from sphinx.util.nodes import nested_parse_with_titles
+
+
+class EmbedN2Directive(Directive):
+    """
+    EmbedN2Directive is a custom directive to build and embed an N2 diagram into docs
+    An example usage would look like this:
+
+    .. embed-n2::
+        ../../examples/model.py
+
+    What the above will do is replace the directive and its arg with an N2 diagram.
+
+    The one required argument is the model file to be diagrammed.
+    Optional arguments are numerical width and height of the embedded object, and
+    "toolbar" if the toolbar should be visible by default.
+
+    Example with width of 1500, height of 800, and toolbar displayed:
+
+    .. embed-n2:
+        ../../examples/model.py
+        1500
+        800
+        toolbar
+
+    """
+
+    required_arguments = 1
+    optional_arguments = 3
+    has_content = True
+
+    def run(self):
+        path_to_model = self.arguments[0]
+        n2_dims = [1200, 700]
+        show_toolbar = False
+
+        if len(self.arguments) > 1 and self.arguments[1]:
+            n2_dim_idx = 0
+            for idx in range(1, len(self.arguments)):
+                if self.arguments[idx] == "toolbar":
+                    show_toolbar = True
+                else:
+                    n2_dims[n2_dim_idx] = self.arguments[idx]
+                    n2_dim_idx = 1
+
+        np = os.path.normpath(os.path.join(os.getcwd(), path_to_model))
+
+        # check that the file exists
+        if not os.path.isfile(np):
+            raise IOError("File does not exist({0})".format(np))
+
+        # Generate N2 files into the target_dir. Those files are later copied
+        # into the top of the HTML hierarchy, so the HTML doc file needs a
+        # relative path to them.
+        target_dir = os.path.join(os.getcwd(), "_n2html")
+
+        rel_dir = os.path.relpath(os.getcwd(), os.path.dirname(self.state.document.settings._source))
+        html_base_name = os.path.basename(path_to_model).split(".")[0] + "_n2.html"
+        html_name = os.path.join(target_dir, html_base_name)
+        html_rel_name = os.path.join(rel_dir, html_base_name)
+        if show_toolbar:
+            html_rel_name += "#toolbar"
+
+        cmd = subprocess.Popen(["openmdao", "n2", np, "--no_browser", "--embed", "-o" + html_name])
+        cmd_out, cmd_err = cmd.communicate()
+
+        rst = ViewList()
+
+        # Add the content one line at a time.
+        # Second argument is the filename to report in any warnings
+        # or errors, third argument is the line number.
+        env = self.state.document.settings.env
+        docname = env.doc2path(env.docname)
+
+        object_tag = (
+            "<iframe width='" + str(n2_dims[0]) + "'"
+            " height='" + str(n2_dims[1]) + "'"
+            " style='border: 1px solid lightgray; resize: both;'"
+            " src='" + html_rel_name + "'></iframe>"
+        )
+
+        rst.append(".. raw:: html", docname, self.lineno)
+        rst.append("", docname, self.lineno)  # leave an empty line
+        rst.append("    %s" % object_tag, docname, self.lineno)
+
+        # Create a node.
+        node = nodes.section()
+
+        # Parse the rst.
+        nested_parse_with_titles(self.state, rst, node)
+
+        # And return the result.
+        return node.children
+
+
+def setup(app):
+    """add custom directive into Sphinx so that it is found during document parsing"""
+    app.add_directive("embed-n2", EmbedN2Directive)
+
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/sphinx_mdolab_theme/ext/embed_shell_cmd.py
+++ b/sphinx_mdolab_theme/ext/embed_shell_cmd.py
@@ -1,0 +1,165 @@
+"""
+Sphinx directive to embed shell command output in the docs.
+
+The shell command is executed and the output is captured.
+"""
+
+# Standard Python modules
+import html as cgiesc
+import os
+import subprocess
+
+# External modules
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives import unchanged
+import sphinx
+from sphinx.errors import SphinxError
+from sphinx.writers.html5 import HTML5Translator
+from sphinx.writers.html import HTMLTranslator
+
+
+class failed_node(nodes.Element):
+    pass
+
+
+def visit_failed_node(self, node):
+    pass
+
+
+def depart_failed_node(self, node):
+    if not isinstance(self, (HTMLTranslator, HTML5Translator)):
+        self.body.append("output only available for HTML\n")
+        return
+
+    html = """
+    <div class="cell border-box-sizing code_cell rendered">
+       <div class="output">
+          <div class="inner_cell">
+             <div class="failed"><pre>{}</pre></div>
+          </div>
+       </div>
+    </div>""".format(
+        node["text"]
+    )
+    self.body.append(html)
+
+
+class cmd_node(nodes.Element):
+    pass
+
+
+def visit_cmd_node(self, node):
+    pass
+
+
+def depart_cmd_node(self, node):
+    """
+    This function creates the formatting that sets up the look of the blocks.
+    The look of the formatting is controlled by _theme/static/style.css
+    """
+    if not isinstance(self, (HTMLTranslator, HTML5Translator)):
+        self.body.append("output only available for HTML\n")
+        return
+
+    html = """
+    <div class="cell border-box-sizing code_cell rendered">
+       <div class="output_area"><pre>{}</pre></div>
+    </div>""".format(
+        node["text"]
+    )
+
+    self.body.append(html)
+
+
+class EmbedShellCmdDirective(Directive):
+    """
+    EmbedShellCmdDirective is a custom directive to allow a shell command and the result
+    of running it to be shown in feature docs.
+    An example usage would look like this:
+
+    .. embed-shell-cmd::
+        :cmd: ls -ltr
+
+    What the above will do is replace the directive and its args with the shell command,
+    run the command, and show the resulting output.
+
+    """
+
+    # must have at least one arg (embedded test) for this to work
+    required_arguments = 0
+    optional_arguments = 0
+    has_content = False
+
+    option_spec = {
+        "cmd": unchanged,  # shell command to execute
+        "dir": unchanged,  # working dir
+        "show_cmd": unchanged,  # set this to make the shell command visible
+        "stderr": unchanged,  # set this to include stderr contents with the output
+    }
+
+    def run(self):
+        """
+        Create a list of document nodes to return.
+        """
+        if "cmd" in self.options:
+            cmdstr = self.options["cmd"]
+            cmd = cmdstr.split()
+        else:
+            raise SphinxError("'cmd' is not defined for embed-shell-cmd.")
+
+        startdir = os.getcwd()
+
+        if "dir" in self.options:
+            workdir = os.path.abspath(os.path.expandvars(os.path.expanduser(self.options["dir"])))
+        else:
+            workdir = os.getcwd()
+
+        if "stderr" in self.options:
+            stderr = subprocess.STDOUT
+        else:
+            stderr = None  # noqa
+
+        os.chdir(workdir)
+
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, env=os.environ).decode("utf-8", "ignore")
+        except subprocess.CalledProcessError as err:
+            # Failed cases raised as a Directive warning (level 2 in docutils).
+            # This way, the sphinx build does not terminate if, for example, you are building on
+            # an environment where mpi or pyoptsparse are missing.
+            msg = "Running of embedded shell command '{}' in docs failed. Output was: \n{}".format(
+                cmdstr, err.output.decode("utf-8")
+            )
+            raise self.directive_error(2, msg)
+        except Exception as err:
+            msg = "Running of embedded shell command '{}' in docs failed. Output was: \n{}".format(cmdstr, err)
+            raise self.directive_error(2, msg)
+        finally:
+            os.chdir(startdir)
+
+        output = cgiesc.escape(output)
+
+        show = True
+        if "show_cmd" in self.options:
+            show = self.options["show_cmd"].lower().strip() == "true"
+
+        if show:
+            input_node = nodes.literal_block(cmdstr, cmdstr)
+            input_node["language"] = "none"
+
+        output_node = cmd_node(text=output)
+
+        if show:
+            return [input_node, output_node]
+        else:
+            return [output_node]
+
+
+def setup(app):
+    """add custom directive into Sphinx so that it is found during document parsing"""
+    app.add_directive("embed-shell-cmd", EmbedShellCmdDirective)
+    app.add_node(failed_node, html=(visit_failed_node, depart_failed_node))
+    app.add_node(cmd_node, html=(visit_cmd_node, depart_cmd_node))
+
+    return {"version": sphinx.__display_version__, "parallel_read_safe": True}

--- a/sphinx_mdolab_theme/ext/tags.py
+++ b/sphinx_mdolab_theme/ext/tags.py
@@ -1,0 +1,80 @@
+# tag.py, this custom Sphinx extension is activated in conf.py
+# and allows the use of the custom directive for tags in our rst (e.g.):
+# .. tags:: tag1, tag2, tag3
+# External modules
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives.admonitions import Admonition
+from sphinx.locale import _
+
+
+# The setup function for the Sphinx extension
+def setup(app):
+    # This adds a new node class to build sys, with custom functs, (same name as file)
+    app.add_node(tag, html=(visit_tag_node, depart_tag_node))
+    # This creates a new ".. tags:: " directive in Sphinx
+    app.add_directive("tags", TagDirective)
+    # These are event handlers, functions connected to events.
+    app.connect("doctree-resolved", process_tag_nodes)
+    app.connect("env-purge-doc", purge_tags)
+    # Identifies the version of our extension
+    return {"version": "0.1"}
+
+
+def visit_tag_node(self, node):
+    self.visit_admonition(node)
+
+
+def depart_tag_node(self, node):
+    self.depart_admonition(node)
+
+
+def purge_tags(app, env, docname):
+    return
+
+
+def process_tag_nodes(app, doctree, fromdocname):
+    env = app.builder.env  # noqa
+
+
+class tag(nodes.Admonition, nodes.Element):
+    pass
+
+
+class TagDirective(Directive):
+    # This allows content in the directive, e.g. to list tags here
+    has_content = True
+
+    def run(self):
+        env = self.state.document.settings.env
+        targetid = "tag-%d" % env.new_serialno("tag")
+        targetnode = nodes.target("", "", ids=[targetid])
+
+        # The tags fetched from the custom directive are one piece of text
+        # sitting in self.content[0]
+        taggs = self.content[0].split(", ")
+        links = []
+
+        for tagg in taggs:
+            # Create Sphinx doc refs of format :ref:`Tagname<Tagname>`
+            link = ":ref:`" + tagg + "<" + tagg + ">`"
+            links.append(link)
+        # Put links back in a single comma-separated string together
+        linkjoin = ", ".join(links)
+
+        # Replace content[0] with hyperlinks to display in admonition
+        self.content[0] = linkjoin
+
+        ad = Admonition(
+            self.name,
+            [_("Tags")],
+            self.options,
+            self.content,
+            self.lineno,
+            self.content_offset,
+            self.block_text,
+            self.state,
+            self.state_machine,
+        )
+
+        return [targetnode] + ad.run()

--- a/sphinx_mdolab_theme/utils/docutil.py
+++ b/sphinx_mdolab_theme/utils/docutil.py
@@ -1,0 +1,925 @@
+"""
+A collection of functions for modifying source code that is embeded into the Sphinx documentation.
+"""
+
+# Standard Python modules
+import ast
+from collections import namedtuple
+import html as cgiesc
+import importlib
+import inspect
+from io import StringIO
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import tokenize
+import traceback
+import unittest
+
+# External modules
+from docutils import nodes
+from redbaron import RedBaron
+from sphinx.errors import SphinxError
+from sphinx.writers.html5 import HTML5Translator
+from sphinx.writers.html import HTMLTranslator
+
+# First party modules
+from sphinx_mdolab_theme.utils.general_utils import printoptions
+
+sqlite_file = "feature_docs_unit_test_db.sqlite"  # name of the sqlite database file
+table_name = "feature_unit_tests"  # name of the table to be queried
+
+_sub_runner = os.path.join(os.path.dirname(os.path.abspath(__file__)), "run_sub.py")
+
+
+# an input block consists of a block of code and a tag that marks the end of any
+# output from that code in the output stream (via inserted print('>>>>>#') statements)
+InputBlock = namedtuple("InputBlock", "code tag")
+
+
+class skipped_or_failed_node(nodes.Element):
+    pass
+
+
+def visit_skipped_or_failed_node(self, node):
+    pass
+
+
+def depart_skipped_or_failed_node(self, node):
+    if not isinstance(self, (HTMLTranslator, HTML5Translator)):
+        self.body.append("output only available for HTML\n")
+        return
+
+    html = '<div class="cell border-box-sizing code_cell rendered"><div class="output"><div class="inner_cell"><div class="{}"><pre>{}</pre></div></div></div></div>'.format(
+        node["kind"], node["text"]
+    )
+    self.body.append(html)
+
+
+class in_or_out_node(nodes.Element):
+    pass
+
+
+def visit_in_or_out_node(self, node):
+    pass
+
+
+def depart_in_or_out_node(self, node):
+    """
+    This function creates the formatting that sets up the look of the blocks.
+    The look of the formatting is controlled by _theme/static/style.css
+    """
+    if not isinstance(self, (HTMLTranslator, HTML5Translator)):
+        self.body.append("output only available for HTML\n")
+        return
+    if node["kind"] == "In":
+        html = '<div class="highlight-python"><div class="highlight"><pre>{}</pre></div></div>'.format(node["text"])
+    elif node["kind"] == "Out":
+        html = '<div class="cell border-box-sizing code_cell rendered"><div class="output_area"><pre>{}</pre></div></div>'.format(
+            node["text"]
+        )
+
+    self.body.append(html)
+
+
+def node_setup(app):
+    app.add_node(skipped_or_failed_node, html=(visit_skipped_or_failed_node, depart_skipped_or_failed_node))
+    app.add_node(in_or_out_node, html=(visit_in_or_out_node, depart_in_or_out_node))
+
+
+def remove_docstrings(source):
+    """
+    Return 'source' minus docstrings.
+
+    Parameters
+    ----------
+    source : str
+        Original source code.
+
+    Returns
+    -------
+    str
+        Source with docstrings removed.
+    """
+    io_obj = StringIO(source)
+    out = ""
+    prev_toktype = tokenize.INDENT
+    last_lineno = -1
+    last_col = 0
+    for tok in tokenize.generate_tokens(io_obj.readline):
+        token_type = tok[0]
+        token_string = tok[1]
+        start_line, start_col = tok[2]
+        end_line, end_col = tok[3]
+        # ltext = tok[4] # in original code but not used here
+        # The following two conditionals preserve indentation.
+        # This is necessary because we're not using tokenize.untokenize()
+        # (because it spits out code with copious amounts of oddly-placed
+        # whitespace).
+        if start_line > last_lineno:
+            last_col = 0
+        if start_col > last_col:
+            out += " " * (start_col - last_col)
+        # This series of conditionals removes docstrings:
+        if token_type == tokenize.STRING:
+            if prev_toktype != tokenize.INDENT:
+                # This is likely a docstring; double-check we're not inside an operator:
+                if prev_toktype != tokenize.NEWLINE:
+                    # Note regarding NEWLINE vs NL: The tokenize module
+                    # differentiates between newlines that start a new statement
+                    # and newlines inside of operators such as parens, brackes,
+                    # and curly braces.  Newlines inside of operators are
+                    # NEWLINE and newlines that start new code are NL.
+                    # Catch whole-module docstrings:
+                    if start_col > 0:
+                        # Unlabelled indentation means we're inside an operator
+                        out += token_string
+                    # Note regarding the INDENT token: The tokenize module does
+                    # not label indentation inside of an operator (parens,
+                    # brackets, and curly braces) as actual indentation.
+                    # For example:
+                    # def foo():
+                    #     "The spaces before this docstring are tokenize.INDENT"
+                    #     test = [
+                    #         "The spaces before this string do not get a token"
+                    #     ]
+        else:
+            out += token_string
+        prev_toktype = token_type
+        last_col = end_col
+        last_lineno = end_line
+    return out
+
+
+def remove_redbaron_node(node, index):
+    """
+    Utility function for removing a node using RedBaron.
+
+    RedBaron has some problems with modifying code lines that run across
+    multiple lines. ( It is mentioned somewhere online but cannot seem to
+    find it now. )
+
+    RedBaron throws an Exception but when you check, it seems like it does
+    what you asked it to do. So, for now, we ignore the Exception.
+    """
+
+    try:
+        node.value.remove(node.value[index])
+    except Exception as e:  # no choice but to catch the general Exception
+        if str(e).startswith("It appears that you have indentation in your CommaList"):
+            pass
+        else:
+            raise
+
+
+def replace_asserts_with_prints(src):
+    """
+    Replace asserts with print statements.
+
+    Using RedBaron, replace some assert calls with print statements that print the actual
+    value given in the asserts. Depending on the calls, the actual value can be the first or second
+    argument.
+
+    Parameters
+    ----------
+    src : str
+        String containing source lines.
+
+    Returns
+    -------
+    str
+        String containing source with asserts replaced by prints.
+    """
+    rb = RedBaron(src)  # convert to RedBaron internal structure
+
+    # findAll is slow, so only check the ones that are present.
+    base_assert = [
+        "assertAlmostEqual",
+        "assertLess",
+        "assertGreater",
+        "assertEqual",
+        "assert_equal_arrays",
+        "assertTrue",
+        "assertFalse",
+    ]
+    used_assert = [item for item in base_assert if item in src]
+
+    for assert_type in used_assert:
+        assert_nodes = rb.findAll("NameNode", value=assert_type)
+        for assert_node in assert_nodes:
+            assert_node = assert_node.parent
+            remove_redbaron_node(assert_node, 0)  # remove 'self' from the call
+            assert_node.value[0].replace("print")
+            if assert_type not in ["assertTrue", "assertFalse"]:
+                # remove the expected value argument
+                remove_redbaron_node(assert_node.value[1], 1)
+
+    if "assert_rel_error" in src:
+        assert_nodes = rb.findAll("NameNode", value="assert_rel_error")
+        for assert_node in assert_nodes:
+            assert_node = assert_node.parent
+            # If relative error tolerance is specified, there are 4 arguments
+            if len(assert_node.value[1]) == 4:
+                # remove the relative error tolerance
+                remove_redbaron_node(assert_node.value[1], -1)
+            remove_redbaron_node(assert_node.value[1], -1)  # remove the expected value
+            # remove the first argument which is the TestCase
+            remove_redbaron_node(assert_node.value[1], 0)
+            #
+            assert_node.value[0].replace("print")
+
+    if "assert_near_equal" in src:
+        assert_nodes = rb.findAll("NameNode", value="assert_near_equal")
+        for assert_node in assert_nodes:
+            assert_node = assert_node.parent
+            # If relative error tolerance is specified, there are 3 arguments
+            if len(assert_node.value[1]) == 3:
+                # remove the relative error tolerance
+                remove_redbaron_node(assert_node.value[1], -1)
+            remove_redbaron_node(assert_node.value[1], -1)  # remove the expected value
+            assert_node.value[0].replace("print")
+
+    if "assert_almost_equal" in src:
+        assert_nodes = rb.findAll("NameNode", value="assert_almost_equal")
+        for assert_node in assert_nodes:
+            assert_node = assert_node.parent
+            # If relative error tolerance is specified, there are 3 arguments
+            if len(assert_node.value[1]) == 3:
+                # remove the relative error tolerance
+                remove_redbaron_node(assert_node.value[1], -1)
+            remove_redbaron_node(assert_node.value[1], -1)  # remove the expected value
+            assert_node.value[0].replace("print")
+
+    return rb.dumps()
+
+
+def remove_initial_empty_lines(source):
+    """
+    Some initial empty lines were added to keep RedBaron happy.
+    Need to strip these out before we pass the source code to the
+    directive for including source code into feature doc files.
+    """
+
+    idx = re.search(r"\S", source, re.MULTILINE).start()
+    return source[idx:]
+
+
+def get_source_code(path):
+    """
+    Return source code as a text string.
+
+    Parameters
+    ----------
+    path : str
+        Path to a file, module, function, class, or class method.
+
+    Returns
+    -------
+    str
+        The source code.
+    int
+        Indentation level.
+    module or None
+        The imported module.
+    class or None
+        The class specified by path.
+    method or None
+        The class method specified by path.
+    """
+
+    indent = 0
+    class_obj = None
+    method_obj = None
+
+    if path.endswith(".py"):
+        if not os.path.isfile(path):
+            raise SphinxError("Can't find file '%s' cwd='%s'" % (path, os.getcwd()))
+        with open(path, "r") as f:
+            source = f.read()
+        module = None
+    else:
+        # First, assume module path since we want to support loading a full module as well.
+        try:
+            module = importlib.import_module(path)
+            source = inspect.getsource(module)
+
+        except ImportError:
+
+            # Second, assume class and see if it works
+            try:
+                parts = path.split(".")
+
+                module_path = ".".join(parts[:-1])
+                module = importlib.import_module(module_path)
+                class_name = parts[-1]
+                class_obj = getattr(module, class_name)
+                source = inspect.getsource(class_obj)
+                indent = 1
+
+            except ImportError:
+
+                # else assume it is a path to a method
+                module_path = ".".join(parts[:-2])
+                module = importlib.import_module(module_path)
+                class_name = parts[-2]
+                method_name = parts[-1]
+                class_obj = getattr(module, class_name)
+                method_obj = getattr(class_obj, method_name)
+                source = inspect.getsource(method_obj)
+                indent = 2
+
+    return remove_leading_trailing_whitespace_lines(source), indent, module, class_obj, method_obj
+
+
+def remove_raise_skip_tests(src):
+    """
+    Remove from the code any raise unittest.SkipTest lines since we don't want those in
+    what the user sees.
+    """
+    rb = RedBaron(src)
+    raise_nodes = rb.findAll("RaiseNode")
+    for rn in raise_nodes:
+        # only the raise for SkipTest
+        if rn.value[:2].dumps() == "unittestSkipTest":
+            rn.parent.value.remove(rn)
+    return rb.dumps()
+
+
+def remove_leading_trailing_whitespace_lines(src):
+    """
+    Remove any leading or trailing whitespace lines.
+
+    Parameters
+    ----------
+    src : str
+        Input code.
+
+    Returns
+    -------
+    str
+        Code with trailing whitespace lines removed.
+    """
+    lines = src.splitlines()
+
+    non_whitespace_lines = []
+    for i, l in enumerate(lines):
+        if l and not l.isspace():
+            non_whitespace_lines.append(i)
+    imin = min(non_whitespace_lines)
+    imax = max(non_whitespace_lines)
+
+    return "\n".join(lines[imin : imax + 1])
+
+
+def is_output_node(node):
+    """
+    Determine whether a RedBaron node may be expected to generate output.
+
+    Parameters
+    ----------
+    node : <Node>
+        a RedBaron Node.
+
+    Returns
+    -------
+    bool
+        True if node may be expected to generate output, otherwise False.
+    """
+    if node.type == "print":
+        return True
+
+    # lines with the following signatures and function names may generate output
+    output_signatures = [("name", "name", "call"), ("name", "name", "name", "call")]
+    output_functions = [
+        "setup",
+        "run_model",
+        "run_driver",
+        "check_partials",
+        "check_totals",
+        "list_inputs",
+        "list_outputs",
+        "list_problem_vars",
+    ]
+
+    if node.type == "atomtrailers" and len(node.value) in (3, 4):
+        sig = []
+        for val in node.value:
+            sig.append(val.type)
+        func_name = node.value[-2].value
+        if tuple(sig) in output_signatures and func_name in output_functions:
+            return True
+
+    return False
+
+
+def split_source_into_input_blocks(src):
+    """
+    Split source into blocks; the splits occur at inserted prints.
+
+    Parameters
+    ----------
+    src : str
+        Input code.
+
+    Returns
+    -------
+    list
+        List of input code sections.
+    """
+    input_blocks = []
+    current_block = []
+
+    for line in src.splitlines():
+        if 'print(">>>>>' in line:
+            tag = line.split('"')[1]
+            code = "\n".join(current_block)
+            input_blocks.append(InputBlock(code, tag))
+            current_block = []
+        else:
+            current_block.append(line)
+
+    if len(current_block) > 0:
+        # final input block, with no associated output
+        code = "\n".join(current_block)
+        input_blocks.append(InputBlock(code, ""))
+
+    return input_blocks
+
+
+def insert_output_start_stop_indicators(src):
+    """
+    Insert identifier strings so that output can be segregated from input.
+
+    Parameters
+    ----------
+    src : str
+        String containing input and output lines.
+
+    Returns
+    -------
+    str
+        String with output demarked.
+    """
+    lines = src.split("\n")
+    print_producing = [
+        "print(",
+        ".setup(",
+        ".run_model(",
+        ".run_driver(",
+        ".check_partials(",
+        ".check_totals(",
+        ".list_inputs(",
+        ".list_outputs(",
+        ".list_sources(",
+        ".list_source_vars(",
+        ".list_problem_vars(",
+        ".list_cases(",
+        ".list_model_options(",
+        ".list_solver_options(",
+    ]
+
+    newlines = []
+    input_block_number = 0
+    in_try = False
+    in_continuation = False
+    head_indent = ""
+    for line in lines:
+        newlines.append(line)
+
+        # Check if we are concluding a continuation line.
+        if in_continuation:
+            line = line.rstrip()
+            if not (line.endswith(",") or line.endswith("\\") or line.endswith("(")):
+                newlines.append('%sprint(">>>>>%d")' % (head_indent, input_block_number))
+                input_block_number += 1
+                in_continuation = False
+
+        # Don't print if we are in a try block.
+        if in_try:
+            if "except" in line:
+                in_try = False
+            continue
+
+        if "try:" in line:
+            in_try = True
+            continue
+
+        # Searching for 'print(' is a little ambiguous.
+        if "set_solver_print(" in line:
+            continue
+
+        for item in print_producing:
+            if item in line:
+                indent = " " * (len(line) - len(line.lstrip()))
+
+                # Line continuations are a litle tricky.
+                line = line.rstrip()
+                if line.endswith(",") or line.endswith("\\") or line.endswith("("):
+                    in_continuation = True
+                    head_indent = indent
+                    break
+
+                newlines.append('%sprint(">>>>>%d")' % (indent, input_block_number))
+                input_block_number += 1
+                break
+
+    return "\n".join(newlines)
+
+
+def consolidate_input_blocks(input_blocks, output_blocks):
+    """
+    Merge any input blocks for which there is no corresponding output
+    with subsequent blocks that do have output.
+
+    Remove any leading and trailing blank lines from all input blocks.
+    """
+    new_input_blocks = []
+    new_block = ""
+
+    for (code, tag) in input_blocks:
+        if tag not in output_blocks:
+            # no output, add to new consolidated block
+            if new_block and not new_block.endswith("\n"):
+                new_block += "\n"
+            new_block += code
+        elif new_block:
+            # add current input to new consolidated block and save
+            if new_block and not new_block.endswith("\n"):
+                new_block += "\n"
+            new_block += code
+            new_block = remove_leading_trailing_whitespace_lines(new_block)
+            new_input_blocks.append(InputBlock(new_block, tag))
+            new_block = ""
+        else:
+            # just strip leading/trailing from input block
+            code = remove_leading_trailing_whitespace_lines(code)
+            new_input_blocks.append(InputBlock(code, tag))
+
+    # trailing input with no corresponding output
+    if new_block:
+        new_block = remove_leading_trailing_whitespace_lines(new_block)
+        new_input_blocks.append(InputBlock(new_block, ""))
+
+    return new_input_blocks
+
+
+def extract_output_blocks(run_output):
+    """
+    Identify and extract outputs from source.
+
+    Parameters
+    ----------
+    run_output : str or list of str
+        Source code with outputs.
+
+    Returns
+    -------
+    dict
+        output blocks keyed on tags like ">>>>>4"
+    """
+    if isinstance(run_output, list):
+        return sync_multi_output_blocks(run_output)
+
+    output_blocks = {}
+    output_block = None
+
+    for line in run_output.splitlines():
+        if output_block is None:
+            output_block = []
+        if line[:5] == ">>>>>":
+            output = ("\n".join(output_block)).strip()
+            if output:
+                output_blocks[line] = output
+            output_block = None
+        else:
+            output_block.append(line)
+
+    if output_block is not None:
+        # It is possible to have trailing output
+        # (e.g. if the last print_producing statement is in a try block)
+        output_blocks["Trailing"] = output_block
+
+    return output_blocks
+
+
+def strip_decorators(src):
+    """
+    Remove any decorators from the source code of the method or function.
+
+    Parameters
+    ----------
+    src : str
+        Source code
+
+    Returns
+    -------
+    str
+        Source code minus any decorators
+    """
+
+    class Parser(ast.NodeVisitor):
+        def __init__(self):
+            self.function_node = None
+
+        def visit_FunctionDef(self, node):
+            self.function_node = node
+
+        def get_function(self):
+            return self.function_node
+
+    tree = ast.parse(src)
+    parser = Parser()
+    parser.visit(tree)
+
+    # get node for the first function
+    function_node = parser.get_function()
+    if not function_node.decorator_list:  # no decorators so no changes needed
+        return src
+
+    # Unfortunately, the ast library, for a decorated function, returns the line
+    #   number for the first decorator when asking for the line number of the function
+    # So using the line number for the argument for of the function, which is always
+    #   correct. But we assume that the argument is on the same line as the function.
+    # We also assume there IS an argument. If not, we raise an error.
+    if function_node.args.args:
+        function_lineno = function_node.args.args[0].lineno
+    else:
+        raise RuntimeError("Cannot determine line number for decorated function without args")
+    lines = src.splitlines()
+
+    undecorated_src = "\n".join(lines[function_lineno - 1 :])
+
+    return undecorated_src
+
+
+def strip_header(src):
+    """
+    Directly manipulating function text to strip header, usually or maybe always just the
+    "def" lines for a method or function.
+
+    This function assumes that the docstring and header, if any, have already been removed.
+
+    Parameters
+    ----------
+    src : str
+        source code
+    """
+    lines = src.split("\n")
+    first_len = None
+    for i, line in enumerate(lines):
+        n1 = len(line)
+        newline = line.lstrip()
+        tab = n1 - len(newline)
+        if first_len is None:
+            first_len = tab
+        elif n1 == 0:
+            continue
+        if tab != first_len:
+            return "\n".join(lines[i:])
+
+    return ""
+
+
+def dedent(src):
+    """
+    Directly manipulating function text to remove leading whitespace.
+
+    Parameters
+    ----------
+    src : str
+        source code
+    """
+
+    lines = src.split("\n")
+    if lines:
+        for i, line in enumerate(lines):
+            lstrip = line.lstrip()
+            if lstrip:  # keep going if first line(s) are blank.
+                tab = len(line) - len(lstrip)
+                return "\n".join(ln[tab:] for ln in lines[i:])
+    return ""
+
+
+def sync_multi_output_blocks(run_output):
+    """
+    Combine output from different procs into the same output blocks.
+
+    Parameters
+    ----------
+    run_output : list of dict
+        List of outputs from individual procs.
+
+    Returns
+    -------
+    dict
+        Synced output blocks from all procs.
+    """
+    if run_output:
+        # for each proc's run output, get a dict of output blocks keyed by tag
+        proc_output_blocks = [extract_output_blocks(outp) for outp in run_output]
+
+        synced_blocks = {}
+
+        for i, outp in enumerate(proc_output_blocks):
+            for tag in outp:
+                if str(outp[tag]).strip():
+                    if tag in synced_blocks:
+                        synced_blocks[tag] += "(rank %d) %s\n" % (i, outp[tag])
+                    else:
+                        synced_blocks[tag] = "(rank %d) %s\n" % (i, outp[tag])
+
+        return synced_blocks
+    else:
+        return {}
+
+
+def run_code(code_to_run, path, module=None, cls=None, shows_plot=False, imports_not_required=False):
+    """
+    Run the given code chunk and collect the output.
+    """
+
+    skipped = False
+    failed = False
+
+    if cls is None:
+        use_mpi = False
+    else:
+        try:
+            # External modules
+            import mpi4py  # noqa
+        except ImportError:
+            use_mpi = False
+        else:
+            N_PROCS = getattr(cls, "N_PROCS", 1)
+            use_mpi = N_PROCS > 1
+
+    try:
+        # use subprocess to run code to avoid any nasty interactions between codes
+
+        # Move to the test directory in case there are files to read.
+        save_dir = os.getcwd()
+
+        if module is None:
+            code_dir = os.path.dirname(os.path.abspath(path))
+        else:
+            code_dir = os.path.dirname(os.path.abspath(module.__file__))
+
+        os.chdir(code_dir)
+
+        if use_mpi:
+            env = os.environ.copy()
+
+            # output will be written to one file per process
+            env["USE_PROC_FILES"] = "1"
+
+            env["OPENMDAO_CURRENT_MODULE"] = module.__name__
+            env["OPENMDAO_CODE_TO_RUN"] = code_to_run
+
+            p = subprocess.Popen(["mpirun", "-n", str(N_PROCS), sys.executable, _sub_runner], env=env)
+            p.wait()
+
+            # extract output blocks from all output files & merge them
+            output = []
+            for i in range(N_PROCS):
+                with open("%d.out" % i) as f:
+                    output.append(f.read())
+                os.remove("%d.out" % i)
+
+        elif shows_plot:
+            if module is None:
+                # write code to a file so we can run it.
+                fd, code_to_run_path = tempfile.mkstemp()
+                with os.fdopen(fd, "w") as tmp:
+                    tmp.write(code_to_run)
+                try:
+                    p = subprocess.Popen(
+                        [sys.executable, code_to_run_path],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        env=os.environ,
+                    )
+                    output, _ = p.communicate()
+                    if p.returncode != 0:
+                        failed = True
+
+                finally:
+                    os.remove(code_to_run_path)
+            else:
+                env = os.environ.copy()
+
+                env["OPENMDAO_CURRENT_MODULE"] = module.__name__
+                env["OPENMDAO_CODE_TO_RUN"] = code_to_run
+
+                p = subprocess.Popen(
+                    [sys.executable, _sub_runner], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
+                )
+                output, _ = p.communicate()
+                if p.returncode != 0:
+                    failed = True
+
+            output = output.decode("utf-8", "ignore")
+        else:
+            # just exec() the code for serial tests.
+
+            # capture all output
+            stdout = sys.stdout
+            stderr = sys.stderr
+            strout = StringIO()
+            sys.stdout = strout
+            sys.stderr = strout
+
+            # We need more precision from numpy
+            with printoptions(precision=8):
+
+                if module is None:
+                    globals_dict = {
+                        "__file__": path,
+                        "__name__": "__main__",
+                        "__package__": None,
+                        "__cached__": None,
+                    }
+                else:
+                    if imports_not_required:
+                        # code does not need to include all imports
+                        # Get from module
+                        globals_dict = module.__dict__
+                    else:
+                        globals_dict = {}
+
+                try:
+                    exec(code_to_run, globals_dict)
+                except Exception as err:
+                    # for actual errors, print code (with line numbers) to facilitate debugging
+                    if not isinstance(err, unittest.SkipTest):
+                        for n, line in enumerate(code_to_run.split("\n")):
+                            print("%4d: %s" % (n, line), file=stderr)
+                    raise
+                finally:
+                    sys.stdout = stdout
+                    sys.stderr = stderr
+
+            output = strout.getvalue()
+
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode("utf-8", "ignore")
+        # Get a traceback.
+        if "raise unittest.SkipTest" in output:
+            reason_for_skip = output.splitlines()[-1][len("unittest.case.SkipTest: ") :]
+            output = reason_for_skip
+            skipped = True
+        else:
+            output = "Running of embedded code {} in docs failed due to: \n\n{}".format(path, output)
+            failed = True
+    except unittest.SkipTest as skip:
+        output = str(skip)
+        skipped = True
+    except Exception:
+        output = "Running of embedded code {} in docs failed due to: \n\n{}".format(path, traceback.format_exc())
+        failed = True
+    finally:
+        os.chdir(save_dir)
+
+    return skipped, failed, output
+
+
+def get_skip_output_node(output):
+    output = "Test skipped because " + output
+    return skipped_or_failed_node(text=output, number=1, kind="skipped")
+
+
+def get_interleaved_io_nodes(input_blocks, output_blocks):
+    """
+    Parameters
+    ----------
+    input_blocks : list of tuple
+        Each tuple is a block of code and the tag marking it's output.
+
+    output_blocks : dict
+        Output blocks keyed on tag.
+    """
+    nodelist = []
+    n = 1
+
+    for (code, tag) in input_blocks:
+        input_node = nodes.literal_block(code, code)
+        input_node["language"] = "python"
+        nodelist.append(input_node)
+        if tag and tag in output_blocks:
+            outp = cgiesc.escape(output_blocks[tag])
+            if outp.strip():
+                output_node = in_or_out_node(kind="Out", number=n, text=outp)
+                nodelist.append(output_node)
+        n += 1
+
+    if "Trailing" in output_blocks:
+        output_node = in_or_out_node(kind="Out", number=n, text=output_blocks["Trailing"])
+        nodelist.append(output_node)
+
+    return nodelist
+
+
+def get_output_block_node(output_blocks):
+    output_block = "\n".join([cgiesc.escape(ob) for ob in output_blocks])
+    return in_or_out_node(kind="Out", number=1, text=output_block)

--- a/sphinx_mdolab_theme/utils/general_utils.py
+++ b/sphinx_mdolab_theme/utils/general_utils.py
@@ -1,0 +1,43 @@
+# Standard Python modules
+from contextlib import contextmanager
+
+# External modules
+import numpy as np
+
+
+@contextmanager
+def printoptions(*args, **kwds):
+    """
+    Context manager for setting numpy print options.
+    Set print options for the scope of the `with` block, and restore the old
+    options at the end. See `numpy.set_printoptions` for the full description of
+    available options. If any invalid options are specified, they will be ignored.
+    Parameters
+    ----------
+    *args : list
+        Variable-length argument list.
+    **kwds : dict
+        Arbitrary keyword arguments.
+    Examples
+    --------
+    >>> with printoptions(precision=2):
+    ...     print(np.array([2.0])) / 3
+    [0.67]
+    The `as`-clause of the `with`-statement gives the current print options:
+    >>> with printoptions(precision=2) as opts:
+    ...      assert_equal(opts, np.get_printoptions())
+    See Also
+    --------
+    set_printoptions, get_printoptions
+    """
+    opts = np.get_printoptions()
+
+    # ignore any keyword args that are not valid in this version of numpy
+    # e.g. numpy <=1.13 does not have the 'floatmode' option
+    kw_opts = dict((key, val) for key, val in kwds.items() if key in opts)
+
+    try:
+        np.set_printoptions(*args, **kw_opts)
+        yield np.get_printoptions()
+    finally:
+        np.set_printoptions(**opts)


### PR DESCRIPTION
## Purpose
This PR ports over sphinx extensions from OpenMDAO 3.9 that are unsupported in OM 3.10 or greater.  Also included is an import sorting configuration file consistent with pyOptSparse.  The `setup.py` file was also modified to include the necessary dependencies for the extensions.

## Expected time until merged
This PR should take a week or less to merge.  As these extensions are difficult to test, it may require another PR to fix bugs that arise once these extensions are used in other MDO Lab documentation.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
