### PR TITLE
Automatically update copyright to current year

### DIFF
--- a/sphinx_mdolab_theme/config.py
+++ b/sphinx_mdolab_theme/config.py
@@ -1,8 +1,9 @@
 import os
+from datetime import datetime
 from .ext.optionslist import TEMP_FILE
 
 # -- Project information -----------------------------------------------------
-project_copyright = "2022, MDO Lab"  # noqa: A001
+project_copyright = f"{datetime.now().year}, MDO Lab"  # noqa: A001
 author = "MDO Lab"
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
## Purpose
Pulls the current year from datetime so we don't have to update the copyright statement every year

## Expected time until merged
This is not urgent but is only 2 lines

## Type of change
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Copyright statement should automatically update to 2023 next year

## Checklist
- [X] I have run `flake8` and `black` to make sure the code adheres to PEP-8 and is consistently formatted
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
