### PR TITLE
Fix flake8 RST issues

### DIFF
--- a/sphinx_mdolab_theme/ext/embed_code.py
+++ b/sphinx_mdolab_theme/ext/embed_code.py
@@ -189,7 +189,6 @@ class EmbedCodeDirective(Directive):
         skipped = failed = False
 
         if "output" in layout or "interleave" in layout or "plot" in layout:
-
             imports_not_required = "imports-not-required" in self.options
 
             if shows_plot:

--- a/sphinx_mdolab_theme/utils/docutil.py
+++ b/sphinx_mdolab_theme/utils/docutil.py
@@ -306,7 +306,6 @@ def get_source_code(path):
             source = inspect.getsource(module)
 
         except ImportError:
-
             # Second, assume class and see if it works
             try:
                 parts = path.split(".")
@@ -319,7 +318,6 @@ def get_source_code(path):
                 indent = 1
 
             except ImportError:
-
                 # else assume it is a path to a method
                 module_path = ".".join(parts[:-2])
                 module = importlib.import_module(module_path)
@@ -538,7 +536,7 @@ def consolidate_input_blocks(input_blocks, output_blocks):
     new_input_blocks = []
     new_block = ""
 
-    for (code, tag) in input_blocks:
+    for code, tag in input_blocks:
         if tag not in output_blocks:
             # no output, add to new consolidated block
             if new_block and not new_block.endswith("\n"):
@@ -832,7 +830,6 @@ def run_code(code_to_run, path, module=None, cls=None, shows_plot=False, imports
 
             # We need more precision from numpy
             with printoptions(precision=8):
-
                 if module is None:
                     globals_dict = {
                         "__file__": path,
@@ -904,7 +901,7 @@ def get_interleaved_io_nodes(input_blocks, output_blocks):
     nodelist = []
     n = 1
 
-    for (code, tag) in input_blocks:
+    for code, tag in input_blocks:
         input_node = nodes.literal_block(code, code)
         input_node["language"] = "python"
         nodelist.append(input_node)

--- a/sphinx_mdolab_theme/utils/docutil.py
+++ b/sphinx_mdolab_theme/utils/docutil.py
@@ -891,6 +891,8 @@ def get_skip_output_node(output):
 
 def get_interleaved_io_nodes(input_blocks, output_blocks):
     """
+    Get interleaved IO nodes
+
     Parameters
     ----------
     input_blocks : list of tuple

--- a/sphinx_mdolab_theme/utils/general_utils.py
+++ b/sphinx_mdolab_theme/utils/general_utils.py
@@ -12,12 +12,14 @@ def printoptions(*args, **kwds):
     Set print options for the scope of the `with` block, and restore the old
     options at the end. See `numpy.set_printoptions` for the full description of
     available options. If any invalid options are specified, they will be ignored.
+
     Parameters
     ----------
-    *args : list
+    \*args : list
         Variable-length argument list.
-    **kwds : dict
+    \*\*kwds : dict
         Arbitrary keyword arguments.
+
     Examples
     --------
     >>> with printoptions(precision=2):
@@ -26,6 +28,7 @@ def printoptions(*args, **kwds):
     The `as`-clause of the `with`-statement gives the current print options:
     >>> with printoptions(precision=2) as opts:
     ...      assert_equal(opts, np.get_printoptions())
+
     See Also
     --------
     set_printoptions, get_printoptions


### PR DESCRIPTION
## Purpose
Per title, this PR partially fixes flake8 RST issues. Issues generated by RST303 are addressed by https://github.com/mdolab/.github/pull/54

## Expected time until merged
1 day

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
